### PR TITLE
add homepage url for rubygems gemspec validation 💎

### DIFF
--- a/lib/life_guard/version.rb
+++ b/lib/life_guard/version.rb
@@ -1,3 +1,3 @@
 module LifeGuard
-  VERSION = "0.4.0"
+  VERSION = "0.4.1"
 end

--- a/life_guard.gemspec
+++ b/life_guard.gemspec
@@ -11,12 +11,12 @@ Gem::Specification.new do |spec|
 
   spec.summary       = %q{Manage the (active_record connection) pool}
   spec.description   = %q{Manage the (active_record connection) pool via Rack middleware}
-  spec.homepage      = "TODO: Put your gem's website or public repo URL here."
+  spec.homepage      = 'http://gems.kitcheck.com'
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.
   if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
+    spec.metadata['allowed_push_host'] = 'http://gems.kitcheck.com'
   else
     raise "RubyGems 2.0 or newer is required to protect against public gem pushes."
   end


### PR DESCRIPTION
- newer versions of ruby gems and bundler raise errors if the `.gemspec` file isn't totally filled out, preventing you from bundling. 
- i'm setting up a new machine with the latest versions of bundler and rubygems, and i can't finish bundling without this change

💎